### PR TITLE
Depend on KFAS, no need to import.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,6 @@ Depends:
 Imports: 
     CholWishart,
     forecast,
-    KFAS,
     MASS,
     Matrix,
     MixMatrix


### PR DESCRIPTION
My sense is that it makes more sense *depend* on KFAS fo that it is always available to causalMBSTS users, but I'm not totally sure. We can discuss here or at https://github.com/FMenchetti/CausalMBSTS/issues/17